### PR TITLE
Configure Project for Jetty Web Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,18 @@
     <description>springboot</description>
     <properties>
         <java.version>17</java.version>
+        <jakarta-servlet.version>5.0.0</jakarta-servlet.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta-servlet.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -24,6 +35,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description:
This pull request introduces configuration changes to use the Jetty web server in Spring boot project.

### Changes:
- **POM Configuration:** Updated the pom.xml to set the Jakarta Servlet version to 5.0.0 and configure the provided dependency for the Jakarta Servlet API.
- **Web Server Configuration:** Removed the Tomcat starter from the Spring Boot dependencies and added the Jetty starter.

### Purpose:
The purpose of this pull request is to configure the project to use the Jetty web server instead of Tomcat. This change can help optimize the project for Jetty-specific features and performance.
